### PR TITLE
Revamp logging payloads

### DIFF
--- a/src/reportGeneration.user.js
+++ b/src/reportGeneration.user.js
@@ -17,7 +17,6 @@
 
     /************* FILL IN FOR PRODUCTION SCRIPT  */
     const TARGET_URL = ""; // Target API endpoint
-    const LOGGING_API_URL = ""; // Logging API endpoint
     /************* FILL IN FOR PRODUCTION SCRIPT  */
 
     // Utility functions
@@ -176,23 +175,20 @@
                     console.log("Member Bookings processed: ", data_response_arr._embedded.items.length);
                     const time_saved = 160 * member_bookings.length;
                     console.log("Time saved: ", time_saved);
-                    logMetricToAWS({
-                        LOGGING_API_URL: LOGGING_API_URL,
+                    sendLog({
                         level: "SUCCESS",
                         message: `Report generated successfully`,
                         feature: "Report Generation",
-                        time_saved : time_saved,
-                        additional: { 
-                            bookingsProcessed: data_response_arr._embedded.items.length,
-                            invalidBookings: data_response_arr._embedded.items - member_bookings.length,
-                        },
+                        details: {
+                            bookingsProcessed: data_response_arr._embedded.items.length
+                        }
                     });
                 } catch (error) {
                     console.error("Error generating report: ", error);
-                    logMetricToAWS({
-                        LOGGING_API_URL: LOGGING_API_URL,
+                    sendLog({
                         level: "ERROR",
                         message: `Error generating report:" ${error.message}`,
+                        feature: "Report Generation"
                     });
                 }
             });
@@ -234,10 +230,10 @@
                     // let formatted_date = stripData(data_response_arr); //TODO: Extract only the necessary data for the LLM 
                 } catch (error) {
                     console.error("Error parsing response data: ", error);
-                    logMetricToAWS({
-                        LOGGING_API_URL,
+                    sendLog({
                         level: "ERROR",
                         message: `Error parsing response data for Report Generation: ${error.message}`,
+                        feature: "Report Generation"
                     });
                 }
             });

--- a/src/signupDateDisplay.user.js
+++ b/src/signupDateDisplay.user.js
@@ -14,7 +14,6 @@
 
     /************* FILL IN FOR PRODUCTION SCRIPT  */
     const TARGET_URL = ""; // Target API endpoint
-    const LOGGING_API_URL = ""; // Logging API endpoint
     /************* FILL IN FOR PRODUCTION SCRIPT  */
 
     // Empty array to store API response data
@@ -188,10 +187,10 @@
                     data_response_arr = JSON.parse(this.responseText);
                 } catch (error) {
                     console.error("Error parsing response data: ", error);
-                    logMetricToAWS({
-                        LOGGING_API_URL,
+                    sendLog({
                         level: "ERROR",
                         message: `Error parsing response data for Date Display: ${error.message}`,
+                        feature: "Signup Date Display"
                     });
                 }
             });

--- a/utilities.js
+++ b/utilities.js
@@ -13,6 +13,9 @@
 
     console.log('Utilities script loaded');
 
+    // Endpoint for structured logging
+    const LOGGING_API_URL = '';
+
     /**
      * Retrieves a value from the browser's localStorage and parses it as JSON.
      *
@@ -74,34 +77,27 @@
     }
 
     /* Example usage:
-    logSuccessToAWS({
-        LOGGING_API_URL: URL,
-        status: "SUCCESS",
-        message: "Successful booking",
-        api_request_param: validbooking[2]
-    });  
-           ^ You don’t need to specify null for missing values */
-           function logMetricToAWS({ LOGGING_API_URL, level, message, feature, time_saved = null, api_request_param = null, api_response_param = null, additional = {} }) {
+    sendLog({
+        level: "SUCCESS",
+        message: "Service Booking created",
+        feature: "Recurring Booking",
+        details: {
+            time_saved: 50,
+            apiRequest: validBookingPayload
+        }
+    }); */
+           function sendLog({ level, message, feature, details = {} }) {
             const timestamp = new Date().toISOString();
-        
-            // Merge all fields into additional 
-            additional = { 
-                ...(time_saved !== null && { time_saved }), 
-                ...(api_request_param !== null && { apiRequest: api_request_param }), 
-                ...(api_response_param !== null && { apiResponse: api_response_param }),
-                ...additional // Ensure custom fields are included
-            };
-        
-            // Prepare payload
+
             const payload = {
                 timestamp,
-                level,  // Ensure level is included
-                feature,
+                level,
                 message,
-                ...(Object.keys(additional).length > 0 && { details: additional }) // Additional parameters if present
+                feature,
+                ...(Object.keys(details).length > 0 && { details })
             };
 
-            // Send log to AWS
+            // Send log to the configured endpoint
             fetch(LOGGING_API_URL, {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
@@ -145,16 +141,17 @@
         console.warn('convertDatetimeToString is already defined and will not be overwritten.');
     }
 
-    // Make the logMetricToAWS function available globally but protect against overwriting
-    if (!window.logMetricToAWS) {
-        Object.defineProperty(window, 'logMetricToAWS', {
-            value: logMetricToAWS,
+
+    // Make the sendLog function available globally but protect against overwriting
+    if (!window.sendLog) {
+        Object.defineProperty(window, 'sendLog', {
+            value: sendLog,
             writable: false, // Prevent overwriting
             configurable: false, // Prevent redefinition
         });
-        console.log('logMetricToAWS function is now globally available.');
+        console.log('sendLog function is now globally available.');
     } else {
-        console.warn('logMetricToAWS is already defined and will not be overwritten.');
+        console.warn('sendLog is already defined and will not be overwritten.');
     }
 
     // Make the getPostHeader function available globally but protect against overwriting


### PR DESCRIPTION
## Summary
- simplify `sendLog` utility and expose `LOGGING_API_URL`
- update all scripts to use `sendLog`
- add structured logging fields for each feature

## Testing
- `node test/calculation_testing.js`


------
https://chatgpt.com/codex/tasks/task_e_684b481d2a34833085513acb041ab204